### PR TITLE
Use Mozilla’s intermediate config settings for https

### DIFF
--- a/templates/nginx/nginx_vhost_totara.conf.erb
+++ b/templates/nginx/nginx_vhost_totara.conf.erb
@@ -10,7 +10,7 @@ server {
 
     server_name <%= @hostname %>;
     <% if @ssl_key && @ssl_cert -%>
-    listen <%= @listen_ssl_port %>;
+    listen <%= @listen_ssl_port %> ssl http2;
     <% else -%>
     listen <%= @listen_port %>;
     <% end -%>
@@ -23,12 +23,13 @@ server {
     charset utf-8;
 
 <% if @ssl_key && @ssl_cert -%>
-    ssl on;
     ssl_certificate     <%= @ssl_cert %>;
     ssl_certificate_key <%= @ssl_key %>;
-    ssl_protocols SSLv3 TLSv1;
-    ssl_ciphers ECDHE-RSA-AES256-SHA384:AES256-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH:!AESGCM;
-    ssl_prefer_server_ciphers on;
+    ssl_dhparam         <%= @ssl_dhparam %>;
+    # intermediate configuration
+    ssl_protocols TLSv1.2;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
 <% end -%>
 
     location / {

--- a/templates/nginx/nginx_vhost_totara.conf.erb
+++ b/templates/nginx/nginx_vhost_totara.conf.erb
@@ -10,7 +10,7 @@ server {
 
     server_name <%= @hostname %>;
     <% if @ssl_key && @ssl_cert -%>
-    listen <%= @listen_ssl_port %> ssl http2;
+    listen <%= @listen_ssl_port %>;
     <% else -%>
     listen <%= @listen_port %>;
     <% end -%>

--- a/templates/nginx/nginx_vhost_totara.conf.erb
+++ b/templates/nginx/nginx_vhost_totara.conf.erb
@@ -25,7 +25,6 @@ server {
 <% if @ssl_key && @ssl_cert -%>
     ssl_certificate     <%= @ssl_cert %>;
     ssl_certificate_key <%= @ssl_key %>;
-    ssl_dhparam         <%= @ssl_dhparam %>;
     # intermediate configuration
     ssl_protocols TLSv1.2;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;


### PR DESCRIPTION
To note, this will need a new value for `ssl_param` defined by any amchines wanting to use https.